### PR TITLE
Move tests to yaml

### DIFF
--- a/overwatcher.py
+++ b/overwatcher.py
@@ -34,6 +34,7 @@ class Overwatcher():
         tf = open(test, "r")
         elems = list(yaml.safe_load_all(tf))[0]
 
+        #Thanks to YAML this was easy
         self.markers = dict(elems['markers'])
         self.prompts = list(elems['prompts'])
         self.triggers = dict(elems['triggers'])
@@ -42,6 +43,9 @@ class Overwatcher():
         self.config_seq = list(elems['initconfig'])
         self.test_seq = list(elems['test'])
 
+        #What we need to worry about are the options
+        for opt in elems['options']:
+            setattr(self, opt, elems['options'][opt])
     """
     -------------------------TEST RESULT FUNCTIONS, called on test ending. Can be overloaded.
     """

--- a/overwatcher.py
+++ b/overwatcher.py
@@ -1,9 +1,12 @@
+#!/usr/bin/python3
+
 import socket
 import random
 import time
 import datetime
 import queue
 import threading
+import argparse
 
 
 class Overwatcher():
@@ -25,7 +28,7 @@ class Overwatcher():
         """
         return
 
-    def setup_test(self, cfg):
+    def setup_test(self, test):
         """
         Function used to setup all test configurations. 
 
@@ -108,10 +111,11 @@ class Overwatcher():
                             "ok":               0
                       }
 
-    def __init__(self, my_vars=None, server='169.168.56.254', port=23200, sendR = False):
+    def __init__(self, test, server='169.168.56.254', port=23200, sendR = False):
 
         """
         Class init. KISS 
+        NOTE: keeping default for backwards compatibility...for now
         """
         #Connection stuff
         self.server = server
@@ -145,7 +149,7 @@ class Overwatcher():
         self.setup_option_defaults()
 
         #Load the user setup
-        self.setup_test(my_vars)
+        self.setup_test(test)
         self.setup_config()
 
         #Open the log file and print everything
@@ -700,3 +704,18 @@ class Overwatcher():
         print("CLOSING FILE")
         self.file_test.close()
         print("CLOSED FILE")
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Ultra-light test framework")
+
+    parser.add_argument('test', help='YAML test file to run')
+    parser.add_argument('--server', help='IP to telnet to',
+            default='localhost')
+    parser.add_argument('--port', help='Port to telnet to',
+            default='3000')
+
+    args = parser.parse_args()
+
+    test = Overwatcher(args.test, server=args.server, port=args.port)
+
+

--- a/overwatcher.py
+++ b/overwatcher.py
@@ -17,28 +17,14 @@ class Overwatcher():
     """
 
     """
-    -------------------------FUNCTIONS THAT NEED TO BE OVERLOADED
+    -------------------------MAIN SETUP FUNCTION. Reads the test file. Can be overloaded
     """
-    def setup_config(self):
-        """
-        Function used to setup the device before the test.
-
-        Can be used to clean-up the setup test if the config is more complicated.
-        Otherwise, everything can be set in the setup_test function
-        """
-        return
-
     def setup_test(self, test):
         """
         Function used to setup all test configurations. 
 
         NOTE: defaults are set before this is called, so only set what you need.
-        """
-        raise NotImplementedError("PLEASE IMPLEMENT THIS IN CHILD CLASSES!")
-
-    def setup_options(self):
-        """
-        Used to set the various self.opt_*** flags and the self.options callbacks.
+        NOTE: for backwards compatibility, this should be kept
         """
         return
 
@@ -150,7 +136,6 @@ class Overwatcher():
 
         #Load the user setup
         self.setup_test(test)
-        self.setup_config()
 
         #Open the log file and print everything
         self.file_test = open(self.name + "_testresults.log", "w", buffering=1)
@@ -178,9 +163,6 @@ class Overwatcher():
 
         #Configure the device
         self.config_device()
-
-        #Set any user options
-        self.setup_options()
 
         #For the normal run, revert back to the normal markers
         self.statewatcher_markers = dict(self.markers)

--- a/overwatcher.py
+++ b/overwatcher.py
@@ -29,7 +29,7 @@ class Overwatcher():
         NOTE: for backwards compatibility, this should be kept
         """
         self.name = os.path.splitext(os.path.basename(test))[0] #Used for log file, get only the name
-        self.full_name = test #Also save the full file path in the logs, because you never know
+        self.full_name = os.path.abspath(test) #Also save the full file path in the logs, because you never know
 
         tf = open(test, "r")
         elems = list(yaml.safe_load_all(tf))[0]

--- a/overwatcher.py
+++ b/overwatcher.py
@@ -694,7 +694,7 @@ if __name__ == "__main__":
     parser.add_argument('--server', help='IP to telnet to',
             default='localhost')
     parser.add_argument('--port', help='Port to telnet to',
-            default='3000')
+            type=int, default=3000)
 
     args = parser.parse_args()
 

--- a/overwatcher.py
+++ b/overwatcher.py
@@ -7,6 +7,8 @@ import datetime
 import queue
 import threading
 import argparse
+import yaml
+import os
 
 
 class Overwatcher():
@@ -26,6 +28,13 @@ class Overwatcher():
         NOTE: defaults are set before this is called, so only set what you need.
         NOTE: for backwards compatibility, this should be kept
         """
+        self.name = os.path.splitext(os.path.basename(test))[0] #Used for log file, get only the name
+        self.full_name = test #Also save the full file path in the logs, because you never know
+
+        tf = open(test, "r")
+        elems = yaml.safe_load_all(tf)
+        for elem in elems:
+            print(elem)
         return
 
     """
@@ -59,7 +68,11 @@ class Overwatcher():
         self.log("\n/\ /\ /\ /\ ENDED CONFIG!/\ /\ /\ /\ \n\n") 
 
     def setup_test_defaults(self):
+        #In case setup_test is overloaded, set these here
+        #NOTE: most likely will be overwritten in setup_test
         self.name = type(self).__name__
+        self.full_name = type(self).__name__
+
         self.timeout = 300.0 #seconds
 
         self.config_seq = []
@@ -98,7 +111,6 @@ class Overwatcher():
                       }
 
     def __init__(self, test, server='169.168.56.254', port=23200, sendR = False):
-
         """
         Class init. KISS 
         NOTE: keeping default for backwards compatibility...for now
@@ -119,7 +131,6 @@ class Overwatcher():
         #Store counts for various triggers
         self.counter = {}
         self.counter["loop"] = 0
-
 
         self.waitPrompt_enter = 100
         self.waitPrompt_return = 2000
@@ -645,6 +656,7 @@ class Overwatcher():
 
     def print_test(self):
         self.file_test.write(self.name + "\n\n")
+        self.file_test.write(self.full_name + "\n\n")
 
         self.file_test.write("MARKERS:\n")
         self.file_test.write(str(self.markers) + "\n")

--- a/overwatcher.py
+++ b/overwatcher.py
@@ -32,10 +32,15 @@ class Overwatcher():
         self.full_name = test #Also save the full file path in the logs, because you never know
 
         tf = open(test, "r")
-        elems = yaml.safe_load_all(tf)
-        for elem in elems:
-            print(elem)
-        return
+        elems = list(yaml.safe_load_all(tf))[0]
+
+        self.markers = dict(elems['markers'])
+        self.prompts = list(elems['prompts'])
+        self.triggers = dict(elems['triggers'])
+        self.actions = dict(elems['actions'])
+
+        self.config_seq = list(elems['initconfig'])
+        self.test_seq = list(elems['test'])
 
     """
     -------------------------TEST RESULT FUNCTIONS, called on test ending. Can be overloaded.


### PR DESCRIPTION
Added ability to have tests in yaml format. Overwatcher is executable and receives the test file as a parameter.

NOTE: old tests should still work OK by overloading the setup_test method, but this is not totally auto. It needs another parameter to the init call for the test and I left it like this to raise a flag when running old tests so I will pay a bit of attention :)